### PR TITLE
fix lose user interaction when app make ephemeral window.

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -13,7 +13,7 @@ BOOL initialized = NO;
 id manager = nil;
 SEL show = nil;
 
-static NSMutableArray *windowsWithGestures = nil;
+static NSHashTable *windowsWithGestures = nil;
 
 static id (*FLXGetManager)();
 static SEL (*FLXRevealSEL)();
@@ -64,7 +64,7 @@ inline BOOL flexAlreadyLoaded() {
         manager = FLXGetManager();
         show = FLXRevealSEL();
 
-        windowsWithGestures = [NSMutableArray new];
+        windowsWithGestures = [NSHashTable weakObjectsHashTable];
         initialized = YES;
     }
 }


### PR DESCRIPTION
Hi @NSExceptional 

Capturing (strong reference) UIWindow is sometimes make a problem for example lose user interaction and eternal showing network loading progress window (PayPay.app; It is mentioned at https://github.com/NSExceptional/FLEXing/issues/13#issuecomment-586676800 by me).

This PR fix that issue by UIWindow deallocation timing control back to application using weak reference to window.

Maybe address the https://github.com/NSExceptional/FLEXing/issues/13 issue.